### PR TITLE
Deduplicate path list before running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Please file your bug reports, enhancement requests, questions and other support 
 
 ## How to Build
 
-1. [Download](http://www.oracle.com/technetwork/developer-tools/sql-developer/downloads/index.html) and install SQL Developer 18.2.0
+1. [Download](http://www.oracle.com/technetwork/developer-tools/sql-developer/downloads/index.html) and install SQL Developer 18.3.0
 2. [Download](https://maven.apache.org/download.cgi) and install Apache Maven 3.5.4
 3. [Download](https://git-scm.com/downloads) and install a git command line client
 4. Clone the utPLSQL-SQLDeveloper repository
@@ -57,7 +57,7 @@ Please file your bug reports, enhancement requests, questions and other support 
 
 6. Run maven build by the following command
 
-		mvn -Dsqldev.basedir=/Applications/SQLDeveloper18.2.0.app/Contents/Resources/sqldeveloper -DskipTests=true clean package
+		mvn -Dsqldev.basedir=/Applications/SQLDeveloper18.3.0.app/Contents/Resources/sqldeveloper -DskipTests=true clean package
 
 	Amend the parameter sqldev.basedir to match the path of your SQL Developer installation. This folder is used to reference Oracle jar files which are not available in public Maven repositories
 7. The resulting file ```utplsql_for_SQLDev_x.x.x-SNAPSHOT.zip``` in the ```target``` directory can be installed within SQL Developer

--- a/sqldev/pom.xml
+++ b/sqldev/pom.xml
@@ -13,7 +13,7 @@
 		<jdk.version.test>1.8</jdk.version.test>
 		<xtend.version>2.15.0</xtend.version>
 		<!-- requires SQL Developer 4.1.0 or higher (first version based on JDK 1.8) -->
-		<sqldev.basedir>/Applications/SQLDeveloper18.2.0.app/Contents/Resources/sqldeveloper</sqldev.basedir>
+		<sqldev.basedir>/Applications/SQLDeveloper18.3.0.app/Contents/Resources/sqldeveloper</sqldev.basedir>
 		<final.name>utplsql_for_SQLDev_${project.version}</final.name>
 	</properties>
 	<dependencies>

--- a/sqldev/src/main/java/org/utplsql/sqldev/oddgen/RunGenerator.xtend
+++ b/sqldev/src/main/java/org/utplsql/sqldev/oddgen/RunGenerator.xtend
@@ -100,7 +100,7 @@ class RunGenerator implements OddgenGenerator2 {
 		return new HashMap<String, Boolean>
 	}
 	
-	def private getPath(Node node, Connection conn) {
+	private def getPath(Node node, Connection conn) {
 		if (node.id == "SUITE" || node.id == "SUITEPATH") {
 			return conn.metaData.userName
 		} else {
@@ -108,7 +108,7 @@ class RunGenerator implements OddgenGenerator2 {
 		}
 	}
 
-	def replaceTabsWithSpaces(CharSequence input, int indentSpaces) {
+	private def replaceTabsWithSpaces(CharSequence input, int indentSpaces) {
 		val spaces = String.format("%1$"+indentSpaces+"s", "")
 		return input.toString.replace("\t", spaces)
 	}


### PR DESCRIPTION
Ensure that path list is deduplicated before running tests. Duplicates are possible when multiple nodes are selected. Without deduplication the tests might be executed multiple times. That is most probably unwanted. 

Other minor changes according commit messages.
