### PR TITLE
Fix for issue #40

### DIFF
--- a/sqldev/pom.xml
+++ b/sqldev/pom.xml
@@ -5,7 +5,7 @@
 	<!-- The Basics -->
 	<groupId>org.utplsql</groupId>
 	<artifactId>org.utplsql.sqldev</artifactId>
-	<version>0.6.0</version>
+	<version>0.6.1</version>
 	<packaging>bundle</packaging>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/sqldev/src/main/java/org/utplsql/sqldev/CodeCoverageReporter.xtend
+++ b/sqldev/src/main/java/org/utplsql/sqldev/CodeCoverageReporter.xtend
@@ -77,7 +77,7 @@ class CodeCoverageReporter {
 			logger.fine('''Running code coverage reporter for «pathList»...''')
 			val dal = new UtplsqlDao(conn)
 			val content = dal.htmlCodeCoverage(pathList, toStringList(schemas), toStringList(includeObjects), toStringList(excludeObjects))
-			val file = File.createTempFile("utplsql_", "html")
+			val file = File.createTempFile("utplsql_", ".html")
 			logger.fine('''Writing result to «file.absolutePath»...''')
 			Files.write(Paths.get(file.absolutePath), content.split(System.lineSeparator), StandardCharsets.UTF_8);
 			val url = file.toURI().toURL().toExternalForm()


### PR DESCRIPTION
- Fixes #40 - added dot `.` before `html` to allow Windows to identify the extension and the associated application (browser)
- pom.xml: release v0.6.1