### PR TITLE
Fixes issue #47 - Connections of unshared worksheets are not closed

### DIFF
--- a/sqldev/pom.xml
+++ b/sqldev/pom.xml
@@ -5,7 +5,7 @@
 	<!-- The Basics -->
 	<groupId>org.utplsql</groupId>
 	<artifactId>org.utplsql.sqldev</artifactId>
-	<version>0.6.3</version>
+	<version>0.6.4</version>
 	<packaging>bundle</packaging>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/sqldev/src/main/java/org/utplsql/sqldev/UtplsqlWorksheet.xtend
+++ b/sqldev/src/main/java/org/utplsql/sqldev/UtplsqlWorksheet.xtend
@@ -43,7 +43,14 @@ class UtplsqlWorksheet {
 
 	private def setConnection(String connectionName) {
 		if (connectionName !== null && preferences.unsharedWorksheet) {
-			this.connectionName = Connections.instance.createPrivateConnection(connectionName)
+			// fix for issue #47 - private connections are not closed in SQLDev >= 17.4.0
+			try {
+				// temporary connection is closed when worksheet is closed, but requires SQLDev >= 17.4.0
+				this.connectionName = Connections.instance.createTemporaryConnection(connectionName)
+			} catch (Throwable e) {
+				// private connection is closed when worksheet is closed in SQLDev < 17.4.0
+				this.connectionName = Connections.instance.createPrivateConnection(connectionName)				
+			}	
 		} else {
 			this.connectionName = connectionName;
 		}


### PR DESCRIPTION
- UtplsqlWorksheet.xtend: 
   - use temporary connections in SQLDev >= 17.4.0
   - use private connections in SQLDev < 17.4.0
- pom.xml: release v0.6.4