### PR TITLE
FIX #59 - always determine executable tests via annotation API before executing tests

### DIFF
--- a/sqldev/pom.xml
+++ b/sqldev/pom.xml
@@ -5,7 +5,7 @@
 	<!-- The Basics -->
 	<groupId>org.utplsql</groupId>
 	<artifactId>org.utplsql.sqldev</artifactId>
-	<version>0.7.1</version>
+	<version>0.7.2-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/sqldev/src/main/java/org/utplsql/sqldev/menu/UtplsqlController.xtend
+++ b/sqldev/src/main/java/org/utplsql/sqldev/menu/UtplsqlController.xtend
@@ -277,8 +277,8 @@ class UtplsqlController implements Controller {
 					connectionName = view.connectionName
 				}
 				logger.fine('''connectionName: «connectionName»''')
-				val preferences = PreferenceModel.getInstance(Preferences.preferences)
-				val parser = new UtplsqlParser(component.text, if (preferences.checkRunUtplsqlTest) {Connections.instance.getConnection(connectionName)} else {null}, owner)
+				// issue 59 - always use a connection to ensure the utPL/SQL annotation API is used
+				val parser = new UtplsqlParser(component.text, Connections.instance.getConnection(connectionName), owner)
 				val position = component.caretPosition
 				val path = parser.getPathAt(position)
 				val utPlsqlWorksheet = new UtplsqlWorksheet(path.pathList, connectionName)


### PR DESCRIPTION
Pro:
- ensures that non-tests procedures are executed

Cons:
- leads to a delay before starting a test (delay is small, even on large schemas)
- delay might be huge for large schemas and empty annotation cache (corner case)