### PR TITLE
#64 - Improve error handling when no utPLSQL is installed

### DIFF
--- a/sqldev/pom.xml
+++ b/sqldev/pom.xml
@@ -5,7 +5,7 @@
 	<!-- The Basics -->
 	<groupId>org.utplsql</groupId>
 	<artifactId>org.utplsql.sqldev</artifactId>
-	<version>1.0.0</version>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/sqldev/src/test/java/org/utplsql/sqldev/test/dal/DalTest.xtend
+++ b/sqldev/src/test/java/org/utplsql/sqldev/test/dal/DalTest.xtend
@@ -588,5 +588,12 @@ class DalTest extends AbstractJdbcTest {
 		Assert.assertEquals("PACKAGE", actual)
 		jdbcTemplate.execute("DROP PACKAGE junit_utplsql_test_pkg")
 	}
+	
+	@Test
+	def void normalizedUtPlsqlVersion() {
+		val dao = new UtplsqlDao(dataSource.connection)
+		val version = dao.normalizedUtPlsqlVersion
+		Assert.assertTrue(version !== null)
+	}
 
 }


### PR DESCRIPTION
Run worksheet runner when no utPLSQL is installed in the database.