### PR TITLE
#63 - Improve code coverage for other schemas

### DIFF
--- a/sqldev/src/main/java/org/utplsql/sqldev/dal/UtplsqlDao.xtend
+++ b/sqldev/src/main/java/org/utplsql/sqldev/dal/UtplsqlDao.xtend
@@ -922,11 +922,11 @@ class UtplsqlDao {
 	 * @param name test package name
 	 * @return list of dependencies in the current schema
 	 */
-	def List<String> includes(String name) {
+	def List<String> includes(String owner, String name) {
 		val sql = '''
-			select referenced_name
+			select referenced_owner || '.' || referenced_name AS dep_name
 			  from «IF dbaViewAccessible»dba«ELSE»all«ENDIF»_dependencies
-			  WHERE owner = user
+			  WHERE owner = upper(?)
 			    AND name = upper(?)
 			    AND referenced_owner NOT IN (
 			           'SYS', 'SYSTEM', 'XS$NULL', 'OJVMSYS', 'LBACSYS', 'OUTLN', 'SYS$UMF', 
@@ -940,7 +940,7 @@ class UtplsqlDao {
 			    AND referenced_owner NOT LIKE 'APEX\_______'
 			    AND referenced_type IN ('PACKAGE', 'TYPE', 'PROCEDURE', 'FUNCTION', 'TRIGGER')
 		'''
-		val deps = jdbcTemplate.queryForList(sql, String, #[name])
+		val deps = jdbcTemplate.queryForList(sql, String, #[owner, name])
 		return deps
 	}
 

--- a/sqldev/src/main/java/org/utplsql/sqldev/menu/UtplsqlController.xtend
+++ b/sqldev/src/main/java/org/utplsql/sqldev/menu/UtplsqlController.xtend
@@ -313,12 +313,21 @@ class UtplsqlController implements Controller {
 			}
 		}
 	}
-	
+
 	def List<String> dependencies(String name, String connectionName) {
 		var List<String> ret = null
 		if (connectionName !== null) {
+			val owner = Connections.instance.getConnection(connectionName).schema
+			ret = dependencies(owner, name, connectionName)
+		}
+		return ret
+	}
+	
+	def List<String> dependencies(String owner, String name, String connectionName) {
+		var List<String> ret = null
+		if (connectionName !== null) {
 			val dao = new UtplsqlDao(Connections.instance.getConnection(connectionName))
-			ret = dao.includes(name)
+			ret = dao.includes(owner, name)
 		}
 		return ret
 	}
@@ -328,12 +337,12 @@ class UtplsqlController implements Controller {
 		for (i : 0 ..< context.selection.length) {
 			val element = context.selection.get(i)
 			if (element instanceof PlSqlNode) {
-				val dep = dependencies(element.objectName, connectionName)
+				val dep = dependencies(element.owner, element.objectName, connectionName)
 				for (d : dep) {
 					ret.add(d)
 				}
 			} else if (element instanceof ChildObjectElement) {
-				val dep = dependencies(element.URL.memberObject, connectionName)
+				val dep = dependencies(element.URL.schema, element.URL.memberObject, connectionName)
 				for (d : dep) {
 					ret.add(d)
 				}

--- a/sqldev/src/test/java/org/utplsql/sqldev/test/dal/DalTest.xtend
+++ b/sqldev/src/test/java/org/utplsql/sqldev/test/dal/DalTest.xtend
@@ -488,10 +488,10 @@ class DalTest extends AbstractJdbcTest {
 			END junit_utplsql_test_pkg;
 		''')
 		val dao = new UtplsqlDao(dataSource.connection)
-		val actualEmpty = dao.includes('TEST_F1')
+		val actualEmpty = dao.includes('SCOTT', 'TEST_F1')
 		Assert.assertEquals(#[], actualEmpty)
-		val actual = dao.includes('junit_utplsql_test_pkg')
-		Assert.assertEquals(#['JUNIT_UTPLSQL_TEST_PKG','JUNIT_F','UT_EXPECTATION'].sort, actual.sort)
+		val actual = dao.includes('SCOTT', 'junit_utplsql_test_pkg')
+		Assert.assertEquals(#['SCOTT.JUNIT_UTPLSQL_TEST_PKG','SCOTT.JUNIT_F','UT3_LATEST_RELEASE.UT_EXPECTATION'].sort, actual.sort)
 	}
 	
 	@Test


### PR DESCRIPTION
- prefix include objects with owner
- calculate dependencies of chosen schema (instead of current user)
