### PR TITLE
#76 - Optmize check "Run utPLSQL test" menu option

### DIFF
--- a/sqldev/src/main/java/org/utplsql/sqldev/dal/UtplsqlDao.xtend
+++ b/sqldev/src/main/java/org/utplsql/sqldev/dal/UtplsqlDao.xtend
@@ -37,7 +37,7 @@ class UtplsqlDao {
 	public static val FIRST_VERSION_WITH_INTERNAL_ANNOTATION_API = 3000004
 	public static val FIRST_VERSION_WITH_ANNOTATION_API = 3001003
 	public static val FIRST_VERSION_WITHOUT_INTERNAL_API = 3001008
-	public static val NOT_YET_AVAILABLE = 9009009
+	public static val FIRST_VERSION_WITH_HAS_SUITES_API = 3001008
 	var Connection conn
 	var JdbcTemplate jdbcTemplate
 	// cache fields
@@ -183,9 +183,8 @@ class UtplsqlDao {
 	 */
 	def boolean containsUtplsqlTest(String owner, String objectName, String subobjectName) {
 		try {
-			if (normalizedUtPlsqlVersionNumber >= NOT_YET_AVAILABLE && objectName !== null && subobjectName !== null) {
-				// use faster check function available since v3.1.3 (FIRST_VERSION_WITH_ANNOTATION_API)
-				// disabled (NOT_YET_AVAILABLE) due to wrong results in v3.1.7
+			if (normalizedUtPlsqlVersionNumber >= org.utplsql.sqldev.dal.UtplsqlDao.FIRST_VERSION_WITH_HAS_SUITES_API && objectName !== null && subobjectName !== null) {
+				// use faster check function available since v3.1.3 (reliable in v3.1.8)
 				val sql = '''
 					DECLARE
 					   l_return VARCHAR2(1) := '0';
@@ -253,9 +252,8 @@ class UtplsqlDao {
 	} 
 	
 	def boolean containsUtplsqlTest(String owner) {
-		if (normalizedUtPlsqlVersionNumber >= NOT_YET_AVAILABLE) {
-			// use faster check function available since v3.1.3 (FIRST_VERSION_WITH_ANNOTATION_API)
-			// disabled (NOT_YET_AVAILABLE) due to wrong results in v3.1.7
+		if (normalizedUtPlsqlVersionNumber >= org.utplsql.sqldev.dal.UtplsqlDao.FIRST_VERSION_WITH_HAS_SUITES_API) {
+			// use faster check function available since v3.1.3 (reliable in v3.1.8)
 			val sql = '''
 				DECLARE
 				   l_return VARCHAR2(1) := '0';
@@ -282,9 +280,8 @@ class UtplsqlDao {
 	}
 	
 	def boolean containsUtplsqlTest(String owner, String objectName) {
-		if (normalizedUtPlsqlVersionNumber >= NOT_YET_AVAILABLE) {
-			// use faster check function available since v3.1.3 (FIRST_VERSION_WITH_ANNOTATION_API)
-			// disabled (NOT_YET_AVAILABLE) due to wrong results in v3.1.7
+		if (normalizedUtPlsqlVersionNumber >= org.utplsql.sqldev.dal.UtplsqlDao.FIRST_VERSION_WITH_HAS_SUITES_API) {
+			// use faster check function available since v3.1.3 (reliable in v3.1.8)
 			val sql = '''
 				DECLARE
 				   l_return VARCHAR2(1) := '0';

--- a/sqldev/src/test/java/org/utplsql/sqldev/test/dal/DalTest.xtend
+++ b/sqldev/src/test/java/org/utplsql/sqldev/test/dal/DalTest.xtend
@@ -25,7 +25,6 @@ import org.springframework.jdbc.BadSqlGrammarException
 import org.utplsql.sqldev.dal.UtplsqlDao
 import org.utplsql.sqldev.model.ut.Annotation
 import org.utplsql.sqldev.test.AbstractJdbcTest
-import org.junit.Ignore
 
 class DalTest extends AbstractJdbcTest {
 	
@@ -147,9 +146,8 @@ class DalTest extends AbstractJdbcTest {
 	}
 	
 	@Test
-	@Ignore
-	def void containsUtplsqlTest999() {
-		containsUtplsqlTest("9.9.9")
+	def void containsUtplsqlTest318() {
+		containsUtplsqlTest("3.1.8")
 	}
 
 	def void annotations(String utPlsqlVersion) {
@@ -206,8 +204,8 @@ class DalTest extends AbstractJdbcTest {
 	}
 	
 	@Test
-	def void annotations999() {
-		annotations("9.9.9")
+	def void annotations318() {
+		annotations("3.1.8")
 	}
 
 	def void testablesPackages(String utPlsqlVersion) {
@@ -252,8 +250,8 @@ class DalTest extends AbstractJdbcTest {
 	}
 
 	@Test
-	def void testablesPackages999() {
-		testablesPackages("9.9.9")
+	def void testablesPackages318() {
+		testablesPackages("3.1.8")
 	}
 
 	def void testablesTypes(String utPlsqlVersion) {
@@ -291,8 +289,8 @@ class DalTest extends AbstractJdbcTest {
 	}
 
 	@Test
-	def void testablesTypes999() {
-		testablesTypes("9.9.9")
+	def void testablesTypes318() {
+		testablesTypes("3.1.8")
 	}
 
 	def void testablesFunctions(String utPlsqlVersion) {
@@ -323,8 +321,8 @@ class DalTest extends AbstractJdbcTest {
 	}
 
 	@Test
-	def void testablesFunctions999() {
-		testablesFunctions("9.9.9")
+	def void testablesFunctions318() {
+		testablesFunctions("3.1.8")
 	}
 
 	def void testablesProcedures(String utPlsqlVersion) {
@@ -355,8 +353,8 @@ class DalTest extends AbstractJdbcTest {
 	}
 
 	@Test
-	def void testablesProcedures999() {
-		testablesProcedures("9.9.9")
+	def void testablesProcedures318() {
+		testablesProcedures("3.1.8")
 	}
 
 	def void runnables(String utPlsqlVersion) {
@@ -422,8 +420,8 @@ class DalTest extends AbstractJdbcTest {
 	}
 	
 	@Test
-	def void runnables999() {
-		runnables("9.9.9")
+	def void runnables318() {
+		runnables("3.1.8")
 	}
 
 	@Test


### PR DESCRIPTION
closes #76, uses has_suites, is_suite and is_test for utPLSQL v3.1.8 and higher