### PR TITLE
Bugfix/issue89 navigation failed

### DIFF
--- a/sqldev/pom.xml
+++ b/sqldev/pom.xml
@@ -5,7 +5,7 @@
 	<!-- The Basics -->
 	<groupId>org.utplsql</groupId>
 	<artifactId>org.utplsql.sqldev</artifactId>
-	<version>1.1.0</version>
+	<version>1.1.1-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/sqldev/src/main/java/org/utplsql/sqldev/model/runner/Expectation.xtend
+++ b/sqldev/src/main/java/org/utplsql/sqldev/model/runner/Expectation.xtend
@@ -28,7 +28,7 @@ class Expectation extends AbstractModel {
 	def getFailureText() {
 		return '''
 			«message.trim»
-			«caller.trim»
+			«caller?.trim»
 		'''.toString.trim
 	}
 	
@@ -38,10 +38,12 @@ class Expectation extends AbstractModel {
 	
 	def getCallerLine() {
 		var Integer line = null
-		val p = Pattern.compile("(?i)\"[^\\\"]+\",\\s+line\\s*([0-9]+)")
-		val m = p.matcher(caller)
-		if (m.find) {
-			line = Integer.valueOf(m.group(1))
+		if (caller !== null) {
+			val p = Pattern.compile("(?i)\"[^\\\"]+\",\\s+line\\s*([0-9]+)")
+			val m = p.matcher(caller)
+			if (m.find) {
+				line = Integer.valueOf(m.group(1))
+			}
 		}
 		return line
 	}

--- a/sqldev/src/test/java/org/utplsql/sqldev/test/dal/DalTest.xtend
+++ b/sqldev/src/test/java/org/utplsql/sqldev/test/dal/DalTest.xtend
@@ -399,11 +399,11 @@ class DalTest extends AbstractJdbcTest {
 		Assert.assertEquals("SCOTT:a", actual.get("SCOTT:a.b"))
 		Assert.assertEquals("SCOTT:a.b", actual.get("SCOTT:a.b.c"))
 		Assert.assertEquals("SCOTT:a.b.c", actual.get("SCOTT:a.b.c.junit_utplsql_test_pkg"))
-		Assert.assertEquals("SCOTT:a.b.c.junit_utplsql_test_pkg", actual.get("SCOTT:a.b.c.junit_utplsql_test_pkg.myContext"))
+		Assert.assertEquals("SCOTT:a.b.c.junit_utplsql_test_pkg.nested_context_#", actual.get("SCOTT:a.b.c.junit_utplsql_test_pkg.nested_context_#1"))
 		Assert.assertEquals("SCOTT:a.b.c.junit_utplsql_test_pkg", actual.get("SCOTT:a.b.c.junit_utplsql_test_pkg.t0"))
 		Assert.assertEquals("SCOTT:a.b.c.junit_utplsql_test_pkg", actual.get("SCOTT:a.b.c.junit_utplsql_test_pkg.t3"))
-		Assert.assertEquals("SCOTT:a.b.c.junit_utplsql_test_pkg.myContext", actual.get("SCOTT:a.b.c.junit_utplsql_test_pkg.myContext.t1"))
-		Assert.assertEquals("SCOTT:a.b.c.junit_utplsql_test_pkg.myContext", actual.get("SCOTT:a.b.c.junit_utplsql_test_pkg.myContext.t2"))
+		Assert.assertEquals("SCOTT:a.b.c.junit_utplsql_test_pkg.nested_context_#1", actual.get("SCOTT:a.b.c.junit_utplsql_test_pkg.nested_context_#1.t1"))
+		Assert.assertEquals("SCOTT:a.b.c.junit_utplsql_test_pkg.nested_context_#1", actual.get("SCOTT:a.b.c.junit_utplsql_test_pkg.nested_context_#1.t2"))
 	}
 
 	@Test
@@ -489,7 +489,7 @@ class DalTest extends AbstractJdbcTest {
 		val actualEmpty = dao.includes('SCOTT', 'TEST_F1')
 		Assert.assertEquals(#[], actualEmpty)
 		val actual = dao.includes('SCOTT', 'junit_utplsql_test_pkg')
-		Assert.assertEquals(#['SCOTT.JUNIT_UTPLSQL_TEST_PKG','SCOTT.JUNIT_F','UT3_LATEST_RELEASE.UT_EXPECTATION'].sort, actual.sort)
+		Assert.assertEquals(#['SCOTT.JUNIT_UTPLSQL_TEST_PKG','SCOTT.JUNIT_F','UT3_LATEST_RELEASE.UT_DATA_VALUE','UT3_LATEST_RELEASE.UT_EXPECTATION'].sort, actual.sort)
 	}
 	
 	@Test


### PR DESCRIPTION
Fixes #89 - Cannot navigate to failed test with throws annotation