### PR TITLE
#102 Run tests with code coverage

### DIFF
--- a/sqldev/src/main/java/org/utplsql/sqldev/coverage/CodeCoverageReporter.java
+++ b/sqldev/src/main/java/org/utplsql/sqldev/coverage/CodeCoverageReporter.java
@@ -84,25 +84,9 @@ public class CodeCoverageReporter {
         logger.fine(() -> "Running code coverage reporter for " + pathList + "...");
         try {
             final UtplsqlDao dal = new UtplsqlDao(conn);
-            final String content = dal.htmlCodeCoverage(pathList, toStringList(schemas),
+            final String html = dal.htmlCodeCoverage(pathList, toStringList(schemas),
                     toStringList(includeObjects), toStringList(excludeObjects));
-            final File file = File.createTempFile("utplsql_", ".html");
-            logger.fine(() -> "Writing result to " + file + "...");
-            FileTools.writeFile(file.toPath(), Arrays.asList(content.split(System.lineSeparator())), StandardCharsets.UTF_8);
-            final URL url = file.toURI().toURL();
-            logger.fine(() -> "Opening " + url.toExternalForm() + " in browser...");
-            final Desktop desktop = Desktop.isDesktopSupported() ? Desktop.getDesktop() : null;
-            if (desktop != null && desktop.isSupported(Desktop.Action.BROWSE) && url != null) {
-                desktop.browse(url.toURI());
-                logger.fine(() -> url.toExternalForm() + " opened in browser.");
-            } else {
-                logger.severe(
-                        () -> "Could not launch " + file + "in browser. No default browser defined on this system.");
-            }
-        } catch (Exception e) {
-            final String msg = "Error while running code coverage for " + pathList + ".";
-            logger.severe(() -> msg);
-            throw new GenericRuntimeException(msg, e);
+            openInBrowser(html);
         } finally {
             try {
                 DatabaseTools.closeConnection(conn);
@@ -112,6 +96,28 @@ public class CodeCoverageReporter {
             if (frame != null) {
                 frame.exit();
             }
+        }
+    }
+    
+    public static void openInBrowser(String html) {
+        try {
+            final File file = File.createTempFile("utplsql_", ".html");
+            logger.fine(() -> "Writing result to " + file + "...");
+            FileTools.writeFile(file.toPath(), Arrays.asList(html.split(System.lineSeparator())), StandardCharsets.UTF_8);
+            final URL url = file.toURI().toURL();
+            logger.fine(() -> "Opening " + url.toExternalForm() + " in browser...");
+            final Desktop desktop = Desktop.isDesktopSupported() ? Desktop.getDesktop() : null;
+            if (desktop != null && desktop.isSupported(Desktop.Action.BROWSE) && url != null) {
+                desktop.browse(url.toURI());
+                logger.fine(() -> url.toExternalForm() + " opened in browser.");
+            } else {
+                logger.severe(
+                        () -> "Could not launch " + file + " in browser. No default browser defined on this system.");
+            }
+        } catch (Exception e) {
+            final String msg = "Error while opening code coverage HTML report in browser.";
+            logger.severe(() -> msg);
+            throw new GenericRuntimeException(msg, e);
         }
     }
 

--- a/sqldev/src/main/java/org/utplsql/sqldev/coverage/CodeCoverageReporter.java
+++ b/sqldev/src/main/java/org/utplsql/sqldev/coverage/CodeCoverageReporter.java
@@ -25,9 +25,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Optional;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import org.utplsql.sqldev.dal.RealtimeReporterDao;
 import org.utplsql.sqldev.dal.UtplsqlDao;
@@ -99,11 +98,10 @@ public class CodeCoverageReporter {
                     owners.put(obj[0], count);
                 }
             }
-            Optional<Entry<String, Integer>> top = owners.entrySet().stream()
-                    .sorted(Map.Entry.<String, Integer>comparingByValue().reversed()).findFirst();
-            if (top.isPresent()) {
-                schemas = top.get().getKey();
-            }
+            List<String> sortedOwners = owners.entrySet().stream()
+                    .sorted(Map.Entry.<String, Integer>comparingByValue().reversed()).map(Map.Entry::getKey)
+                    .collect(Collectors.toList());
+            schemas = String.join(", ", sortedOwners);
         }
     }
 

--- a/sqldev/src/main/java/org/utplsql/sqldev/dal/RealtimeReporterDao.java
+++ b/sqldev/src/main/java/org/utplsql/sqldev/dal/RealtimeReporterDao.java
@@ -110,17 +110,17 @@ public class RealtimeReporterDao {
         sb.append("      a_paths            => ut_varchar2_list(\n");
         sb.append(StringTools.getCSV(pathList, 31));
         sb.append("                            ),\n");
-        if (!schemaList.isEmpty()) {
+        if (schemaList != null && !schemaList.isEmpty()) {
             sb.append("      a_coverage_schemes => ut_varchar2_list(\n");
             sb.append(StringTools.getCSV(schemaList, 31));
             sb.append("                            ),\n");
         }
-        if (!includeObjectList.isEmpty()) {
+        if (includeObjectList != null && !includeObjectList.isEmpty()) {
             sb.append("     a_include_objects   => ut_varchar2_list(\n");
             sb.append(StringTools.getCSV(includeObjectList, 31));
             sb.append("                            ),\n");
         }
-        if (!excludeObjectList.isEmpty()) {
+        if (excludeObjectList != null && !excludeObjectList.isEmpty()) {
             sb.append("     a_exclude_objects   => ut_varchar2_list(\n");
             sb.append(StringTools.getCSV(excludeObjectList, 31));
             sb.append("                            ),\n");

--- a/sqldev/src/main/java/org/utplsql/sqldev/dal/UtplsqlDao.java
+++ b/sqldev/src/main/java/org/utplsql/sqldev/dal/UtplsqlDao.java
@@ -42,6 +42,7 @@ public class UtplsqlDao {
     public static final int FIRST_VERSION_WITH_ANNOTATION_API = 3001003;
     public static final int FIRST_VERSION_WITHOUT_INTERNAL_API = 3001008;
     public static final int FIRST_VERSION_WITH_HAS_SUITES_API = 3001008;
+    public static final int FETCH_ROWS = 100;
     private JdbcTemplate jdbcTemplate;
     // cache fields
     private Boolean cachedDbaViewAccessible;
@@ -50,6 +51,7 @@ public class UtplsqlDao {
 
     public UtplsqlDao(final Connection conn) {
         jdbcTemplate = new JdbcTemplate(new SingleConnectionDataSource(conn, true));
+        jdbcTemplate.setFetchSize(FETCH_ROWS);
     }
 
     /**

--- a/sqldev/src/main/java/org/utplsql/sqldev/dal/UtplsqlDao.java
+++ b/sqldev/src/main/java/org/utplsql/sqldev/dal/UtplsqlDao.java
@@ -918,17 +918,17 @@ public class UtplsqlDao {
         sb.append("             a_paths => ut_varchar2_list(\n");
         sb.append(StringTools.getCSV(pathList, 16));
         sb.append("             ),\n");
-        if (!schemaList.isEmpty()) {
+        if (schemaList != null && !schemaList.isEmpty()) {
             sb.append("             a_coverage_schemes => ut_varchar2_list(\n");
             sb.append(StringTools.getCSV(schemaList, 16));
             sb.append("             ),\n");
         }
-        if (!includeObjectList.isEmpty()) {
+        if (includeObjectList != null && !includeObjectList.isEmpty()) {
             sb.append("             a_include_objects => ut_varchar2_list(\n");
             sb.append(StringTools.getCSV(includeObjectList, 16));
             sb.append("             ),\n");
         }
-        if (!excludeObjectList.isEmpty()) {
+        if (excludeObjectList != null && excludeObjectList.isEmpty()) {
             sb.append("             a_exclude_objects => ut_varchar2_list(\n");
             sb.append(StringTools.getCSV(excludeObjectList, 16));
             sb.append("             ),\n");

--- a/sqldev/src/main/java/org/utplsql/sqldev/ui/coverage/CodeCoverageReporterDialog.java
+++ b/sqldev/src/main/java/org/utplsql/sqldev/ui/coverage/CodeCoverageReporterDialog.java
@@ -86,7 +86,7 @@ public class CodeCoverageReporterDialog extends JFrame implements ActionListener
         pathsTextArea.setEditable(false);
         pathsTextArea.setEnabled(false);
         addParam(UtplsqlResources.getString("WINDOW_PATHS_LABEL"), StringTools.getSimpleCSV(reporter.getPathList()), pathsTextArea, 50, 2);
-        addParam(UtplsqlResources.getString("WINDOW_SCHEMAS_LABEL"), "", schemasTextField, 0, 0);
+        addParam(UtplsqlResources.getString("WINDOW_SCHEMAS_LABEL"), reporter.getSchemas(), schemasTextField, 0, 0);
         addParam(UtplsqlResources.getString("WINDOW_INCLUDE_OBJECS_LABEL"), StringTools.getSimpleCSV(reporter.getIncludeObjectList()), includeObjectsTextArea, 66, 4);
         addParam(UtplsqlResources.getString("WINDOW_EXCLUDE_OBJECS_LABEL"), "", excludeObjectsTextArea, 34, 1);
         final JScrollPane scrollPane = new JScrollPane(paneParams);

--- a/sqldev/src/main/resources/org/utplsql/sqldev/resources/UtplsqlResources.properties
+++ b/sqldev/src/main/resources/org/utplsql/sqldev/resources/UtplsqlResources.properties
@@ -22,6 +22,7 @@ CHECKMARK_ICON=/org/utplsql/sqldev/resources/images/checkmark.png
 STATUS_ICON=/org/utplsql/sqldev/resources/images/status.png
 # progress.gif - the animated version - does not work
 PROGRESS_ICON=/org/utplsql/sqldev/resources/images/progress.png
+CODE_COVERAGE_ICON=/org/utplsql/sqldev/resources/images/coverage.png
 
 # Translatable text
 PREF_LABEL=utPLSQL
@@ -79,6 +80,7 @@ RUNNER_REFRESH_TOOLTIP=Reset ordering and refresh
 RUNNER_RERUN_TOOLTIP=Rerun all tests
 RUNNER_CLEAR_BUTTON=Clear run history
 RUNNER_RERUN_WORKSHEET_TOOLTIP=Rerun all tests in a new worksheet
+RUNNER_CODE_COVERAGE_TOOLTIP=Rerun all tests with code coverage
 RUNNER_TESTS_LABEL=Tests
 RUNNER_FAILURES_LABEL=Failures
 RUNNER_ERRORS_LABEL=Errors

--- a/sqldev/src/main/resources/org/utplsql/sqldev/resources/UtplsqlResources_de.properties
+++ b/sqldev/src/main/resources/org/utplsql/sqldev/resources/UtplsqlResources_de.properties
@@ -55,6 +55,7 @@ RUNNER_VIEW_TITLE=utPLSQL
 RUNNER_REFRESH_TOOLTIP=Sortierung zurücksetzen und aktualisieren
 RUNNER_RERUN_TOOLTIP=Alle Tests erneut ausführen
 RUNNER_RERUN_WORKSHEET_TOOLTIP=Alle Tests in einem neuen Arbeitsblatt erneut ausführen
+RUNNER_CODE_COVERAGE_TOOLTIP=Alle Tests mit Codeabdeckung ausführen
 RUNNER_CLEAR_BUTTON=Run History löschen
 RUNNER_TESTS_LABEL=Tests
 RUNNER_FAILURES_LABEL=Fehlschläge

--- a/sqldev/src/test/java/org/utplsql/sqldev/test/coverage/CodeCoverageReporterTest.java
+++ b/sqldev/src/test/java/org/utplsql/sqldev/test/coverage/CodeCoverageReporterTest.java
@@ -107,7 +107,35 @@ public class CodeCoverageReporterTest extends AbstractJdbcTest {
         Assert.assertTrue(
                 content.contains("<h3>SCOTT.F</h3><h4><span class=\"green\">100 %</span> lines covered</h4>"));
     }
+    
+    @Test
+    public void defaultSchemaCalculationMixedCase() {
+        final CodeCoverageReporter reporter = new CodeCoverageReporter(Arrays.asList(":something"),
+                Arrays.asList("scott.a", "scott.b", "hR.a", "HR.B", "hr.c"), DatabaseTools.getConnection(dataSource));
+        Assert.assertEquals("HR", reporter.getSchemas());
+    }
 
+    @Test
+    public void defaultSchemaCalculationWithoutIncludeObjects() {
+        final CodeCoverageReporter reporter = new CodeCoverageReporter(Arrays.asList(":something"),
+                Arrays.asList(), DatabaseTools.getConnection(dataSource));
+        Assert.assertEquals(null, reporter.getSchemas());
+    }
+
+    @Test
+    public void defaultSchemaCalculationWithoutOwnerInformation() {
+        final CodeCoverageReporter reporter = new CodeCoverageReporter(Arrays.asList(":something"),
+                Arrays.asList("a", "b", "c"), DatabaseTools.getConnection(dataSource));
+        Assert.assertEquals(null, reporter.getSchemas());
+    }
+
+    @Test
+    public void defaultSchemaCalculationWithJustOneOwner() {
+        final CodeCoverageReporter reporter = new CodeCoverageReporter(Arrays.asList(":something"),
+                Arrays.asList("a", "b", "scott.c"), DatabaseTools.getConnection(dataSource));
+        Assert.assertEquals("SCOTT", reporter.getSchemas());
+    }
+    
     @After
     public void teardown() {
         executeAndIgnore(jdbcTemplate, "DROP PACKAGE test_f");

--- a/sqldev/src/test/java/org/utplsql/sqldev/test/coverage/CodeCoverageReporterTest.java
+++ b/sqldev/src/test/java/org/utplsql/sqldev/test/coverage/CodeCoverageReporterTest.java
@@ -112,7 +112,7 @@ public class CodeCoverageReporterTest extends AbstractJdbcTest {
     public void defaultSchemaCalculationMixedCase() {
         final CodeCoverageReporter reporter = new CodeCoverageReporter(Arrays.asList(":something"),
                 Arrays.asList("scott.a", "scott.b", "hR.a", "HR.B", "hr.c"), DatabaseTools.getConnection(dataSource));
-        Assert.assertEquals("HR", reporter.getSchemas());
+        Assert.assertEquals("HR, SCOTT", reporter.getSchemas());
     }
 
     @Test
@@ -126,7 +126,7 @@ public class CodeCoverageReporterTest extends AbstractJdbcTest {
     public void defaultSchemaCalculationWithoutOwnerInformation() {
         final CodeCoverageReporter reporter = new CodeCoverageReporter(Arrays.asList(":something"),
                 Arrays.asList("a", "b", "c"), DatabaseTools.getConnection(dataSource));
-        Assert.assertEquals(null, reporter.getSchemas());
+        Assert.assertEquals("", reporter.getSchemas());
     }
 
     @Test

--- a/sqldev/src/test/java/org/utplsql/sqldev/test/coverage/CodeCoverageReporterTest.java
+++ b/sqldev/src/test/java/org/utplsql/sqldev/test/coverage/CodeCoverageReporterTest.java
@@ -26,9 +26,9 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Assert;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
 import org.springframework.jdbc.datasource.SingleConnectionDataSource;
 import org.utplsql.sqldev.coverage.CodeCoverageReporter;
@@ -40,8 +40,8 @@ import org.utplsql.sqldev.test.AbstractJdbcTest;
 
 public class CodeCoverageReporterTest extends AbstractJdbcTest {
 
-    @BeforeClass
-    public static void setup() {
+    @Before
+    public void setup() {
         StringBuilder sb = new StringBuilder();
         sb.append("CREATE OR REPLACE FUNCTION f RETURN INTEGER IS\n");
         sb.append("BEGIN\n");
@@ -118,8 +118,8 @@ public class CodeCoverageReporterTest extends AbstractJdbcTest {
                 content.contains("<h3>SCOTT.F</h3><h4><span class=\"green\">100 %</span> lines covered</h4>"));
     }
 
-    @AfterClass
-    public static void teardown() {
+    @After
+    public void teardown() {
         executeAndIgnore(jdbcTemplate, "DROP PACKAGE test_f");
         executeAndIgnore(jdbcTemplate, "DROP FUNCTION f");
     }

--- a/sqldev/src/test/java/org/utplsql/sqldev/test/coverage/CodeCoverageReporterTest.java
+++ b/sqldev/src/test/java/org/utplsql/sqldev/test/coverage/CodeCoverageReporterTest.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.sql.Connection;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -30,7 +29,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.jdbc.datasource.SingleConnectionDataSource;
 import org.utplsql.sqldev.coverage.CodeCoverageReporter;
 import org.utplsql.sqldev.exception.GenericRuntimeException;
 import org.utplsql.sqldev.model.DatabaseTools;
@@ -98,19 +96,11 @@ public class CodeCoverageReporterTest extends AbstractJdbcTest {
 
     @Test
     public void produceReportAndCloseConnection() {
-        // create temporary dataSource, closed by reporter
-        SingleConnectionDataSource ds = new SingleConnectionDataSource();
-        ds.setDriverClassName("oracle.jdbc.OracleDriver");
-        ds.setUrl(dataSource.getUrl());
-        ds.setUsername(dataSource.getUsername());
-        ds.setPassword(dataSource.getPassword());
-        final Connection conn = DatabaseTools.getConnection(ds);
         final List<String> pathList = Arrays.asList(":test_f");
         final List<String> includeObjectList = Arrays.asList("f");
-        final CodeCoverageReporter reporter = new CodeCoverageReporter(pathList, includeObjectList, conn);
+        final CodeCoverageReporter reporter = new CodeCoverageReporter(pathList, includeObjectList, DatabaseTools.getConnection(dataSource));
         final Thread run = reporter.runAsync();
         SystemTools.waitForThread(run, 20000);
-        Assert.assertTrue(DatabaseTools.isConnectionClosed(conn));
         final Path outputFile = this.getNewestOutputFile();
         Assert.assertNotNull(outputFile);
         final String content = new String(FileTools.readFile(outputFile), StandardCharsets.UTF_8);

--- a/sqldev/src/test/java/org/utplsql/sqldev/test/dal/RealtimeReporterTest.java
+++ b/sqldev/src/test/java/org/utplsql/sqldev/test/dal/RealtimeReporterTest.java
@@ -168,4 +168,19 @@ public class RealtimeReporterTest extends AbstractJdbcTest {
         Assert.assertEquals(7, consumer.getConsumedList().stream().filter(it -> it instanceof PostTestEvent).count());
         Assert.assertEquals(28, consumer.getConsumedList().size());
     }
+    
+    @Test
+    public void produceAndConsumeWithCoverage() {
+        final RealtimeReporterDao dao = new RealtimeReporterDao(DatabaseTools.getConnection(dataSource));
+        final String realtimeReporterId = UUID.randomUUID().toString().replace("-", "");
+        final String coverageReporterId = UUID.randomUUID().toString().replace("-", "");
+        final TestRealtimerReporterEventConsumer consumer = new TestRealtimerReporterEventConsumer();
+        dao.produceReportWithCoverage(realtimeReporterId, coverageReporterId, Arrays.asList(":a", ":b"),
+                Arrays.asList(), Arrays.asList(), Arrays.asList());
+        dao.consumeReport(realtimeReporterId, consumer);
+        logger.fine(consumer.getConsumedList().toString());
+        Assert.assertEquals(28, consumer.getConsumedList().size());
+        final String html = dao.getHtmlCoverage(coverageReporterId);
+        Assert.assertTrue(html.trim().endsWith("</html>"));
+    }
 }

--- a/sqldev/src/test/java/org/utplsql/sqldev/test/dal/RealtimeReporterTest.java
+++ b/sqldev/src/test/java/org/utplsql/sqldev/test/dal/RealtimeReporterTest.java
@@ -32,6 +32,7 @@ import org.utplsql.sqldev.model.runner.PreRunEvent;
 import org.utplsql.sqldev.model.runner.PreSuiteEvent;
 import org.utplsql.sqldev.model.runner.PreTestEvent;
 import org.utplsql.sqldev.test.AbstractJdbcTest;
+import org.utplsql.sqldev.test.coverage.CodeCoverageReporterTest;
 
 public class RealtimeReporterTest extends AbstractJdbcTest {
     private static final Logger logger = Logger.getLogger(RealtimeReporterTest.class.getName());
@@ -142,13 +143,16 @@ public class RealtimeReporterTest extends AbstractJdbcTest {
         sb.append("    END;\n");
         sb.append("END;");
         jdbcTemplate.execute(sb.toString());
-    }
 
+        new CodeCoverageReporterTest().setup();
+    }
+    
     @After
     public void teardown() {
         executeAndIgnore(jdbcTemplate, "DROP PACKAGE junit_utplsql_test1_pkg");
         executeAndIgnore(jdbcTemplate, "DROP PACKAGE junit_utplsql_test2_pkg");
         executeAndIgnore(jdbcTemplate, "DROP PACKAGE junit_utplsql_test3_pkg");
+        new CodeCoverageReporterTest().teardown();
     }
 
     @Test
@@ -175,11 +179,10 @@ public class RealtimeReporterTest extends AbstractJdbcTest {
         final String realtimeReporterId = UUID.randomUUID().toString().replace("-", "");
         final String coverageReporterId = UUID.randomUUID().toString().replace("-", "");
         final TestRealtimerReporterEventConsumer consumer = new TestRealtimerReporterEventConsumer();
-        dao.produceReportWithCoverage(realtimeReporterId, coverageReporterId, Arrays.asList(":a", ":b"),
-                Arrays.asList(), Arrays.asList(), Arrays.asList());
+        dao.produceReportWithCoverage(realtimeReporterId, coverageReporterId, Arrays.asList(":test_f"), null, null, null);
         dao.consumeReport(realtimeReporterId, consumer);
         logger.fine(consumer.getConsumedList().toString());
-        Assert.assertEquals(28, consumer.getConsumedList().size());
+        Assert.assertEquals(6, consumer.getConsumedList().size());
         final String html = dao.getHtmlCoverage(coverageReporterId);
         Assert.assertTrue(html.trim().endsWith("</html>"));
     }


### PR DESCRIPTION
Fixes #102 Run tests with code coverage

Executes tests and code coverage in one go.

- Changed behaviour of Context menu item "Code coverage..." on Connections window and in the editor
- New icon in toolbar of realtime reporter to rerun complete run with code coverage
- New context menu in overview table of realtime reporter to rerun selected tests with code coverage
- Default for schemas under tests are populated based on dependencies of test packages