### PR TITLE
#107 - Crash of Realtime Report when server output contains <![CDATA[...]]>

### DIFF
--- a/sqldev/src/main/java/org/utplsql/sqldev/dal/RealtimeReporterDao.java
+++ b/sqldev/src/main/java/org/utplsql/sqldev/dal/RealtimeReporterDao.java
@@ -28,7 +28,6 @@ import javax.xml.parsers.DocumentBuilder;
 import org.springframework.jdbc.core.CallableStatementCallback;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.SingleConnectionDataSource;
-import org.utplsql.sqldev.exception.GenericRuntimeException;
 import org.utplsql.sqldev.model.StringTools;
 import org.utplsql.sqldev.model.XMLTools;
 import org.utplsql.sqldev.model.runner.Counter;
@@ -234,13 +233,15 @@ public class RealtimeReporterDao {
             }
             return event;
         } catch (SAXException e) {
+            // continue processing, see https://github.com/utPLSQL/utPLSQL-SQLDeveloper/issues/107
             final String msg = "Parse error while processing " + itemType + " with content: " + text;
             logger.severe(() -> msg);
-            throw new GenericRuntimeException(msg, e);
+            return null;
         } catch (IOException e) {
+            // continue processing, see https://github.com/utPLSQL/utPLSQL-SQLDeveloper/issues/107
             final String msg = "I/O error while processing " + itemType + " with content: " + text;
             logger.severe(() -> msg);
-            throw new GenericRuntimeException(msg, e);
+            return null;
         }
     }
 

--- a/sqldev/src/main/java/org/utplsql/sqldev/dal/RealtimeReporterDao.java
+++ b/sqldev/src/main/java/org/utplsql/sqldev/dal/RealtimeReporterDao.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2018 Philipp Salvisberg <philipp.salvisberg@trivadis.com>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -211,8 +211,8 @@ public class RealtimeReporterDao {
             rs.close();
             return sb1.toString();
         });
-    }    
-    
+    }
+
     private RealtimeReporterEvent convert(final String itemType, final String text) {
         logger.fine(() -> "\n---- " + itemType + " ----\n" + text);
         try {

--- a/sqldev/src/main/java/org/utplsql/sqldev/runner/UtplsqlRunner.java
+++ b/sqldev/src/main/java/org/utplsql/sqldev/runner/UtplsqlRunner.java
@@ -173,6 +173,10 @@ public class UtplsqlRunner implements RealtimeReporterEventConsumer {
         return df.format(dateTime);
     }
 
+    public boolean isRunning() {
+        return run != null && run.getEndTime() == null;
+    }
+
     private void initRun() {
         run = new Run(realtimeReporterId, connectionName, pathList);
         run.setStartTime(getSysdate());

--- a/sqldev/src/main/resources/org/utplsql/sqldev/resources/UtplsqlResources.properties
+++ b/sqldev/src/main/resources/org/utplsql/sqldev/resources/UtplsqlResources.properties
@@ -90,6 +90,7 @@ RUNNER_CODE_COVERAGE_TOOLTIP=Rerun all tests with code coverage
 RUNNER_STOP_TOOLTIP=Stops the consumer session of the current test run immediately, the JDBC connection might be closed delayed
 RUNNER_STOP_TEST_MESSAGE=Test disabled due to abortion of the test run.
 RUNNER_STOP_RUN_MESSAGE=Test run aborted.
+RUNNER_MISSING_TEST_RESULT_MESSAGE=Missing test results.
 RUNNER_CLEAR_BUTTON=Clear run history
 RUNNER_TESTS_LABEL=Tests
 RUNNER_FAILURES_LABEL=Failures

--- a/sqldev/src/main/resources/org/utplsql/sqldev/resources/UtplsqlResources_de.properties
+++ b/sqldev/src/main/resources/org/utplsql/sqldev/resources/UtplsqlResources_de.properties
@@ -63,6 +63,7 @@ RUNNER_CODE_COVERAGE_TOOLTIP=Alle Tests mit Codeabdeckung ausf\u00fchren
 RUNNER_STOP_TOOLTIP=Stoppt die Verbrauchersitzung des aktuellen Testlaufs, die JDBC-Verbindung wird m\00f6glicherweise verz\00fgert geschlossen
 RUNNER_STOP_TEST_MESSAGE=Test wurde aufgrund eines Abbruchs des Testlaufs deaktiviert.
 RUNNER_STOP_RUN_MESSAGE=Testlauf abgebrochen.
+RUNNER_MISSING_TEST_RESULT_MESSAGE=Testergebnis fehlt.
 RUNNER_CLEAR_BUTTON=Run History l\u00f6schen
 RUNNER_TESTS_LABEL=Tests
 RUNNER_FAILURES_LABEL=Fehlschl\u00e4ge

--- a/sqldev/src/test/resources/logging.conf
+++ b/sqldev/src/test/resources/logging.conf
@@ -12,7 +12,7 @@ handlers=java.util.logging.ConsoleHandler
 
 # Loggers 
 #oracle.level=FINE
-org.utplsql.level=ALL
+org.utplsql.level=INFO
 
 # --- ConsoleHandler --- 
 java.util.logging.ConsoleHandler.level=ALL


### PR DESCRIPTION
Fixes #107 Crash of Realtime Report when server output contains <![CDATA[...]]>
- Ignoring errors when processing invalid XML messages
- Fix counters in realtime reporter due to unprocessed messages